### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+tensorflow>=2
+scikit-learn
+opencv-python
+pycryptodome
+websocket
+tqdm
+dropbox
+testresources
+setuptools==49.6.0
+Cython
+numpy==1.19.4
+pycuda
+tensorrt


### PR DESCRIPTION
I created requirements.txt to make it easier to install all the dependencies I could find.
Use `pip install -r requirements.txt` to use it.